### PR TITLE
index.php linea 10

### DIFF
--- a/dashboard/index.php
+++ b/dashboard/index.php
@@ -7,7 +7,7 @@
     
     
  <?php
-include_once '/bd/conexion.php';
+include_once './bd/conexion.php';
 $objeto = new Conexion();
 $conexion = $objeto->Conectar();
 


### PR DESCRIPTION
SOLUCIÓN AL ERROR DE CARGA COMO ESTE:
![index-lohg](https://github.com/infodp/login_dashboard_crud/assets/163362692/c416b4b7-a1d2-4c0d-96f2-f5a9800b2f52)

Se agregó un punto antes del simbolo / en la linea 10 del archivo index.php de la carpeta DASHBOARD
![index](https://github.com/infodp/login_dashboard_crud/assets/163362692/03c9eddc-17b5-4378-a31b-9e457b0e5548)

LUEGO DE AGREGAR ESE PUNTO TODO CARGÓ CORRECTAMENTE